### PR TITLE
Adds more monoids

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ let v = vec![Some(1), Some(3)];
 assert_eq!(combine_all(&v), Some(4));
 
 // Slightly more magical
-let t1 = (1, 2.5f32, String::from("hi"), Some(3));
-let t2 = (1, 2.5f32, String::from(" world"), None);
-let t3 = (1, 2.5f32, String::from(", goodbye"), Some(10));
+let t1 =       (1, 2.5f32,                String::from("hi"),  Some(3));
+let t2 =       (1, 2.5f32,            String::from(" world"),     None);
+let t3 =       (1, 2.5f32,         String::from(", goodbye"), Some(10));
 let tuples = vec![t1, t2, t3];
 
 let expected = (3, 7.5f32, String::from("hi world, goodbye"), Some(13));

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -208,7 +208,7 @@ tuple_impls! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::super::semigroup::{ Sum, Product };
+    use super::super::semigroup::{Sum, Product};
     use std::collections::*;
 
     #[test]

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -54,7 +54,9 @@ impl Monoid for String {
     }
 }
 
-impl<T> Monoid for Vec<T> where T: Clone {
+impl<T> Monoid for Vec<T>
+    where T: Clone
+{
     fn empty() -> Self {
         Vec::new()
     }
@@ -78,12 +80,16 @@ impl<K, V> Monoid for HashMap<K, V>
 }
 
 impl Monoid for All<bool> {
-    fn empty() -> Self { All(true) }
+    fn empty() -> Self {
+        All(true)
+    }
 }
 
 
 impl Monoid for Any<bool> {
-    fn empty() -> Self { Any(false) }
+    fn empty() -> Self {
+        Any(false)
+    }
 }
 
 macro_rules! numeric_all_impls {
@@ -285,24 +291,24 @@ mod tests {
     }
 
     #[test]
-    fn test_combine_all_all(){
+    fn test_combine_all_all() {
         let v1: Vec<All<i32>> = Vec::new();
         assert_eq!(combine_all(&v1), All(!0));
         assert_eq!(combine_all(&vec![All(3), All(7)]), All(3));
 
-        let v2 : Vec<All<bool>> = Vec::new();
+        let v2: Vec<All<bool>> = Vec::new();
         assert_eq!(combine_all(&v2), All(true));
         assert_eq!(combine_all(&vec![All(false), All(false)]), All(false));
         assert_eq!(combine_all(&vec![All(true), All(true)]), All(true));
     }
 
     #[test]
-    fn test_combine_all_any(){
+    fn test_combine_all_any() {
         let v1: Vec<Any<i32>> = Vec::new();
         assert_eq!(combine_all(&v1), Any(0));
         assert_eq!(combine_all(&vec![Any(3), Any(8)]), Any(11));
 
-        let v2 : Vec<Any<bool>> = Vec::new();
+        let v2: Vec<Any<bool>> = Vec::new();
         assert_eq!(combine_all(&v2), Any(false));
         assert_eq!(combine_all(&vec![Any(false), Any(false)]), Any(false));
         assert_eq!(combine_all(&vec![Any(true), Any(false)]), Any(true));

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -1,4 +1,4 @@
-use super::semigroup::{Semigroup, Sum, Product};
+use super::semigroup::{Semigroup, Product};
 use std::collections::*;
 use std::hash::Hash;
 
@@ -102,31 +102,6 @@ numeric_monoid_imps! {
     0f64; f64
 }
 
-macro_rules! numeric_sum_monoid_imps {
-  ($($zero: expr; $tr:ty),*) => {
-    $(
-      impl Monoid for Sum<$tr> {
-        fn empty() -> Self { Sum($zero) }
-      }
-    )*
-  }
-}
-
-numeric_sum_monoid_imps! {
-    0; i8,
-    0; i16,
-    0; i32,
-    0; i64,
-    0; u8,
-    0; u16,
-    0; u32,
-    0; u64,
-    0; isize,
-    0; usize,
-    0f32; f32,
-    0f64; f64
-}
-
 macro_rules! numeric_product_monoid_imps {
   ($($one: expr; $tr:ty),*) => {
     $(
@@ -208,7 +183,7 @@ tuple_impls! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::super::semigroup::{Sum, Product};
+    use super::super::semigroup::{Product};
     use std::collections::*;
 
     #[test]
@@ -285,12 +260,6 @@ mod tests {
 
         let expected = (3, 7.5f32, String::from("hi world, goodbye"), Some(13));
         assert_eq!(combine_all(&tuples), expected)
-    }
-
-    #[test]
-    fn test_combine_all_sum() {
-        let v = vec![Sum(2), Sum(3), Sum(4)];
-        assert_eq!(combine_all(&v), Sum(9))
     }
 
     #[test]

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -1,4 +1,4 @@
-use super::semigroup::Semigroup;
+use super::semigroup::{Semigroup, Sum, Product};
 use std::collections::*;
 use std::hash::Hash;
 
@@ -102,6 +102,56 @@ numeric_monoid_imps! {
     0f64; f64
 }
 
+macro_rules! numeric_sum_monoid_imps {
+  ($($zero: expr; $tr:ty),*) => {
+    $(
+      impl Monoid for Sum<$tr> {
+        fn empty() -> Self { Sum($zero) }
+      }
+    )*
+  }
+}
+
+numeric_sum_monoid_imps! {
+    0; i8,
+    0; i16,
+    0; i32,
+    0; i64,
+    0; u8,
+    0; u16,
+    0; u32,
+    0; u64,
+    0; isize,
+    0; usize,
+    0f32; f32,
+    0f64; f64
+}
+
+macro_rules! numeric_product_monoid_imps {
+  ($($one: expr; $tr:ty),*) => {
+    $(
+      impl Monoid for Product<$tr> {
+        fn empty() -> Self { Product($one) }
+      }
+    )*
+  }
+}
+
+numeric_product_monoid_imps! {
+    1; i8,
+    1; i16,
+    1; i32,
+    1; i64,
+    1; u8,
+    1; u16,
+    1; u32,
+    1; u64,
+    1; isize,
+    1; usize,
+    1f32; f32,
+    1f64; f64
+}
+
 
 macro_rules! tuple_impls {
     () => {}; // no more
@@ -158,6 +208,7 @@ tuple_impls! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::super::semigroup::{ Sum, Product };
     use std::collections::*;
 
     #[test]
@@ -234,6 +285,18 @@ mod tests {
 
         let expected = (3, 7.5f32, String::from("hi world, goodbye"), Some(13));
         assert_eq!(combine_all(&tuples), expected)
+    }
+
+    #[test]
+    fn test_combine_all_sum() {
+        let v = vec![Sum(2), Sum(3), Sum(4)];
+        assert_eq!(combine_all(&v), Sum(9))
+    }
+
+    #[test]
+    fn test_combine_all_product() {
+        let v = vec![Product(2), Product(3), Product(4)];
+        assert_eq!(combine_all(&v), Product(24))
     }
 
 }

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -290,6 +290,8 @@ mod tests {
         assert_eq!(combine_all(&v1), All(!0));
         assert_eq!(combine_all(&vec![All(3), All(7)]), All(3));
 
+        let v2 : Vec<All<bool>> = Vec::new();
+        assert_eq!(combine_all(&v2), All(true));
         assert_eq!(combine_all(&vec![All(false), All(false)]), All(false));
         assert_eq!(combine_all(&vec![All(true), All(true)]), All(true));
     }

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -1,6 +1,6 @@
 use std::cell::*;
 use std::hash::Hash;
-use std::ops::{ Deref, BitAnd, BitOr };
+use std::ops::{Deref, BitAnd, BitOr};
 use std::cmp::Ordering;
 use std::collections::{HashSet, HashMap};
 use std::collections::hash_map::Entry;
@@ -195,24 +195,28 @@ impl<K, V> Semigroup for HashMap<K, V>
     }
 }
 
-impl<T> Semigroup for Max<T> where T: Ord + Clone {
+impl<T> Semigroup for Max<T>
+    where T: Ord + Clone
+{
     fn combine(&self, other: &Self) -> Self {
         let x = self.0.clone();
         let y = other.0.clone();
         match x.cmp(&y) {
             Ordering::Less => Max(y),
-            _ => Max(x)
+            _ => Max(x),
         }
     }
 }
 
-impl<T> Semigroup for Min<T> where T: Ord + Clone {
+impl<T> Semigroup for Min<T>
+    where T: Ord + Clone
+{
     fn combine(&self, other: &Self) -> Self {
         let x = self.0.clone();
         let y = other.0.clone();
         match x.cmp(&y) {
             Ordering::Less => Min(x),
-            _ => Min(y)
+            _ => Min(y),
         }
     }
 }


### PR DESCRIPTION
Adds `Sum` and `Product` monoids, while leaving the default numeric monoids to be
`Sum`.  

Example usage:

```rust
    #[test]
    fn test_combine_all_sum() {
        let v = vec![Sum(2), Sum(3), Sum(4)];
        assert_eq!(combine_all(&v), Sum(9))
    }

    #[test]
    fn test_combine_all_product() {
        let v = vec![Product(2), Product(3), Product(4)];
        assert_eq!(combine_all(&v), Product(24))
    }
```

@astynax I'm not sure if there's an issue with providing a default monoid to work on naked numbers, but my reasons for doing so are:

1. Efficiency (no need to wrap and unwrap at runtime)
2. Ergonomics
3. Scala libs like Cats provide Sum Monoids by default so at least it isn't unexpected.